### PR TITLE
fix: unescape `item_code`

### DIFF
--- a/pos_bahrain/public/js/addons/withBatchField.js
+++ b/pos_bahrain/public/js/addons/withBatchField.js
@@ -5,7 +5,7 @@ export default function withBatchField(Pos) {
             this._render_batch_field();
         }
         _render_batch_field() {
-            const item = this.item_data.find(item => item.item_code === this.item_code);
+            const item = this.item_data.find(item => item.item_code === unescape(this.item_code));
             if (item.has_batch_no) {
                 const $selected_item_action = this.wrapper.find('.pos-selected-item-action');
                 $(`
@@ -18,7 +18,7 @@ export default function withBatchField(Pos) {
                 const idx = this.wrapper.find('.pos-bill-item.active').data('idx');
                 const item = this.frm.doc.items[idx];
                 const $select = this.wrapper.find('.pos-item-batch');
-                this.batch_no_data[this.item_code].forEach(batch_no => {
+                this.batch_no_data[unescape(this.item_code)].forEach(batch_no => {
                     const opts = {
                         value: batch_no,
                         selected: item && batch_no === item.batch_no

--- a/pos_bahrain/public/js/addons/withUom.js
+++ b/pos_bahrain/public/js/addons/withUom.js
@@ -43,7 +43,7 @@ export default function withUom(Pos) {
       `).prependTo(this.wrapper.find('.pos-selected-item-action'));
       const $select = this.wrapper.find('.pos-item-uom');
       const selected_item = this._get_active_item_ref_from_doc();
-      this.uom_details[this.item_code].forEach(({ uom }) => {
+      this.uom_details[unescape(this.item_code)].forEach(({ uom }) => {
         $('<option />', {
           value: uom,
           selected: selected_item && uom === selected_item.uom,

--- a/pos_bahrain/public/js/addons/withUom.js
+++ b/pos_bahrain/public/js/addons/withUom.js
@@ -53,7 +53,7 @@ export default function withUom(Pos) {
       });
       $select.on('change', e => {
         e.stopPropagation();
-        this._set_item_price_from_uom(this.item_code, e.target.value);
+        this._set_item_price_from_uom(unescape(this.item_code), e.target.value);
         this.render_selected_item();
       });
     }


### PR DESCRIPTION
**Overview**
Item names are escaped in POS v12. Item codes must be `unescape` to use existing customizations.
https://github.com/frappe/erpnext/commit/578bdff141ad98456e30f6e97eb4f67c89c9a066#diff-4587afa7de9293bd34a849748074d47416ae39d1bc4ff80e62b7aa153e8f2b49

**Screenshot**
![image](https://user-images.githubusercontent.com/5818544/97016584-7c937300-157f-11eb-9f98-5e5b895f234c.png)
