### PR TITLE
fix(vat_on_sales_per_gcc): fix concatv not concatenated to glp_clauses

### DIFF
--- a/pos_bahrain/pos_bahrain/report/vat_on_sales_per_gcc/vat_on_sales_per_gcc.py
+++ b/pos_bahrain/pos_bahrain/report/vat_on_sales_per_gcc/vat_on_sales_per_gcc.py
@@ -66,14 +66,16 @@ def _get_filters(doctype, filters):
         else:
             frappe.throw(msg, exc=VatCategoryNotFound)
 
-    inv_clauses = concatv(
-        ["d.docstatus = 1"],
-        ["d.posting_date BETWEEN %(from_date)s AND %(to_date)s"],
-        ["IFNULL(dt.account_head, '') != ''"],
-        ["dt.account_head {} %(tax_accounts)s".format("IN" if is_include else "NOT IN")],
-        ["d.company = %(company)s"] if filters.get('company') else [],
-        ["d.cost_center = %(cost_center)s"] if filters.get('cost_center') else [],
-        ["d.set_warehouse = %(warehouse)s"] if filters.get('warehouse') else [],
+    inv_clauses = list(
+        concatv(
+            ["d.docstatus = 1"],
+            ["d.posting_date BETWEEN %(from_date)s AND %(to_date)s"],
+            ["IFNULL(dt.account_head, '') != ''"],
+            ["dt.account_head {} %(tax_accounts)s".format("IN" if is_include else "NOT IN")],
+            ["d.company = %(company)s"] if filters.get('company') else [],
+            ["d.cost_center = %(cost_center)s"] if filters.get('cost_center') else [],
+            ["d.set_warehouse = %(warehouse)s"] if filters.get('warehouse') else [],
+        )
     )
     glp_clauses = concatv(
         inv_clauses, ["d.payment_type IN %(payment_types)s", "a.account_type = 'Tax'"]


### PR DESCRIPTION
Due to `Python` behavior on `.join()` function, glp_clauses didn't merged with the inv_clauses. 
Reports generated may include all GL Payments because filters of posting_date `from` and `to` is not merged for the GL Payment fetching data.