### PR TITLE
Updated quotation.js

### DIFF
--- a/pos_bahrain/public/js/quotation.js
+++ b/pos_bahrain/public/js/quotation.js
@@ -22,7 +22,7 @@ function _create_custom_buttons(frm) {
       frappe.datetime.get_diff(
         frm.doc.valid_till,
         frappe.datetime.get_today()
-      ) > 0
+      ) >= 0
     ) {
       frm.add_custom_button(
         __('Sales Invoice'),


### PR DESCRIPTION
fixed the logic issue where sales invoice button will not show if quotation doc was opened on the day of expiry.