### PR TITLE
disable core feature of auto deleting batches when a purchase invoice is cancelled

### DIFF
--- a/pos_bahrain/api/auto_delete_batch.py
+++ b/pos_bahrain/api/auto_delete_batch.py
@@ -1,0 +1,28 @@
+from __future__ import unicode_literals
+import frappe
+import json
+from six import string_types
+from erpnext.controllers.stock_controller import StockController
+# import frappe
+
+def delete_auto_created_batches_override(self):
+	# import frappe
+	dont_delete_batch = frappe.db.get_single_value('POS Bahrain Settings', "do_not_delete_batch_with_purchase_receipt")
+	if dont_delete_batch and self.doctype == 'Purchase Receipt':
+		return
+		
+	for d in self.items:
+		if not d.batch_no: continue
+
+		serial_nos = [sr.name for sr in frappe.get_all("Serial No",
+			{'batch_no': d.batch_no, 'status': 'Inactive'})]
+
+		if serial_nos:
+			frappe.db.set_value("Serial No", { 'name': ['in', serial_nos] }, "batch_no", None)
+
+		d.batch_no = None
+		d.db_set("batch_no", None)
+
+	for data in frappe.get_all("Batch",
+		{'reference_name': self.name, 'reference_doctype': self.doctype}):
+		frappe.delete_doc("Batch", data.name)

--- a/pos_bahrain/hooks.py
+++ b/pos_bahrain/hooks.py
@@ -362,6 +362,7 @@ override_whitelisted_methods = {
     "erpnext.accounts.doctype.sales_invoice.pos.get_pos_data": "pos_bahrain.api.item.get_pos_data",  # noqa
     "erpnext.accounts.doctype.sales_invoice.pos.make_invoice": "pos_bahrain.api.pos.make_invoice",  # noqa
     "erpnext.selling.page.point_of_sale.point_of_sale.search_serial_or_batch_or_barcode_number": "pos_bahrain.api.item.search_serial_or_batch_or_barcode_number",  # noqa
+    # "erpnext.controllers.stock_controller.delete_auto_created_batches":"pos_bahrain.api.auto_delete_batch.delete_auto_created_batches_override"
 }
 
 
@@ -382,7 +383,7 @@ from erpnext.controllers.stock_controller import StockController
 def delete_auto_created_batches_override(self):
 	import frappe
 	dont_delete_batch = frappe.db.get_single_value('POS Bahrain Settings', "do_not_delete_batch_with_purchase_receipt")
-	if dont_delete_batch and self.doctype == 'Purchase Receipt':
+	if dont_delete_batch and (self.doctype == 'Purchase Receipt' or self.doctype == 'Purchase Invoice'):
 		return
 		
 	for d in self.items:

--- a/pos_bahrain/pos_bahrain/doctype/pos_bahrain_settings/pos_bahrain_settings.json
+++ b/pos_bahrain/pos_bahrain/doctype/pos_bahrain_settings/pos_bahrain_settings.json
@@ -393,7 +393,7 @@
    "default": "0",
    "fieldname": "do_not_delete_batch_with_purchase_receipt",
    "fieldtype": "Check",
-   "label": "Do Not Delete Batch with Purchase Receipt"
+   "label": "Do Not Delete Batch with Purchase Receipt and Purchase Invoice"
   },
   {
    "default": "0",
@@ -403,7 +403,7 @@
   }
  ],
  "issingle": 1,
- "modified": "2022-05-12 15:48:31.230858",
+ "modified": "2022-06-07 11:15:42.261403",
  "modified_by": "Administrator",
  "module": "Pos Bahrain",
  "name": "POS Bahrain Settings",


### PR DESCRIPTION
disable core feature of auto deleting batches when a purchase invoice is cancelled